### PR TITLE
Add StartupWMClass to desktop entry

### DIFF
--- a/waterfox-kde/waterfox.desktop
+++ b/waterfox-kde/waterfox.desktop
@@ -121,6 +121,7 @@ Categories=Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;
 StartupNotify=true
 Actions=NewWindow;NewPrivateWindow;ProfileManagerWindow;
+StartupWMClass=waterfox-g
 
 [Desktop Action NewWindow]
 Name=Open a New Window


### PR DESCRIPTION
Without this, at least Unity 7 thinks the Waterfox window is a separate icon in the launcher from the pinned one and thus shows up twice. This occurs only when Waterfox restarts itself.

![unity launcher showing two waterfox icons](https://github.com/hawkeye116477/waterfox-deb-rpm-arch-AppImage/assets/6003656/fdd48f98-03ed-4552-b0e2-3d45ef0a5852)
