### PR TITLE
Update waterfox-classic.desktop with StartupWMClass=waterfox

### DIFF
--- a/waterfox-classic-kpe/waterfox-classic.desktop
+++ b/waterfox-classic-kpe/waterfox-classic.desktop
@@ -121,6 +121,7 @@ Categories=Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;application/vnd.mozilla.xul+xml;text/mml;
 StartupNotify=true
 Actions=NewWindow;NewPrivateWindow;ProfileManagerWindow;
+StartupWMClass=waterfox
 
 [Desktop Action NewWindow]
 Name=Open a New Window

--- a/waterfox/waterfox-wayland.desktop
+++ b/waterfox/waterfox-wayland.desktop
@@ -121,6 +121,8 @@ Categories=Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;
 StartupNotify=true
 Actions=NewWindow;NewPrivateWindow;ProfileManagerWindow;
+StartupWMClass=waterfox-g
+
 
 [Desktop Action NewWindow]
 Name=Open a New Window

--- a/waterfox/waterfox.desktop
+++ b/waterfox/waterfox.desktop
@@ -121,7 +121,8 @@ Categories=Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;
 StartupNotify=true
 Actions=NewWindow;NewPrivateWindow;ProfileManagerWindow;
-StartupWMClass=waterfox
+StartupWMClass=waterfox-g
+
 
 [Desktop Action NewWindow]
 Name=Open a New Window


### PR DESCRIPTION
hello! 🙂
Gnome dash shows generic icon, if desktop file doesn't have a right StartupWMClass=
so if you can merge this its cool 👍
maybe correct it , but in my distro its that 